### PR TITLE
Refactor variable alb_arn to accept a list of strings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf" {
 }
 
 resource "aws_wafv2_web_acl_association" "waf" {
-  resource_arn = var.alb_arn
+  for_each     = toset(var.alb_arn)
+  resource_arn = each.key
   web_acl_arn  = aws_wafv2_web_acl.waf.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "alb_arn" {
-  description = "ARN of the Application Load Balancer (ALB) to associate WAF rules"
-  type        = string
+  description = "List of ARN(s) of the Application Load Balancers (ALB) to associate WAF rules"
+  type        = list(string)
 }
 
 # AWS Managed Rules rule groups list


### PR DESCRIPTION
Resource: aws_elastic_beanstalk_environment attribute load_balancers is a list of  Elastic load balancers in use by this Environment. Refactored the module to accept a list of ARN(s) for ALBs.